### PR TITLE
Fix unwanted scrolling in reply headers on mobile.

### DIFF
--- a/style/mobile.css
+++ b/style/mobile.css
@@ -262,27 +262,6 @@ margin:auto!important;
 text-align:center!important;
 }
 
-.c:after {
-clear:both;
-content:".";
-display:block;
-height:0;
-margin-bottom:.001em;
-visibility:hidden;
-}
-
-.c {
-display:inline-block;
-}
-
-html[xmlns] .c {
-display:block;
-}
-
-* html .c {
-height:1%;
-}
-
 #error,label,legend,#hot_topics a {
 font-weight:700!important;
 }


### PR DESCRIPTION
Fixes #41.
The rule `.c:after` in `styles/mobile.css` causes undesired scrolling in `h3.c` elements.
Removing this rule has doesn't cause any issues after testing in Chrome on Mac OS X (spoofing the user-agent) and the default Android browser (Samsung S5).
As the 3 following rules also appear to all be related to the same workaround (and their presence just may not be required in modern browsers), this pull request removes all of them.