### PR TITLE
Fix watchlist check / uncheck all by reworking it completely

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1246,17 +1246,23 @@ class table
     private $output = '';
     private $primary_key;
     private $columns = array();
+    private $table_tag;
     private $td_classes = array();
     private $marker_printed = false;
     private $last_seen = false;
     private $order_time = false;
     private $odd = false;
 
+    public function __construct($classes='') {
+        $this->table_tag = '<table class="'.$classes.'">';
+    }
+
     public function define_columns($all_columns, $primary_column)
     {
         $this->columns = $all_columns;
 
-        $this->output .= '<table>'.indent().'<thead>'.indent(2).'<tr>';
+        $this->output .= $this->table_tag
+                      .indent().'<thead>'.indent(2).'<tr>';
 
         foreach ($all_columns as $key => $column) {
             $this->output .=   indent(3).' <th class="';
@@ -1268,6 +1274,11 @@ class table
             $this->output .= string_to_stylesheet_class($column).'">'.$column.'</th>';
         }
         $this->output .=  indent(2).'</tr>'.indent().'</thead>'.indent().'<tbody>';
+    }
+
+    public function add_table_class($class)
+    {
+        $this->table_classes = $class;
     }
 
     public function add_td_class($column_name, $class)

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -342,17 +342,27 @@ function quickCite(id){
 	return false;
 }
 
-window.checkOrUncheckAllCheckboxes = checkOrUncheckAllCheckboxes;
-function checkOrUncheckAllCheckboxes() {
-	tmp = document.tinybbs_tmp;
-	for (i = 0; i < tmp.elements.length; i++) {
-		if (tmp.elements[i].type == 'checkbox') {
-			if (tmp.master_checkbox.checked == true)
-				tmp.elements[i].checked = true;
-			else
-				tmp.elements[i].checked = false;
-		}
-	}
+/*
+ * When a table has the "selectable" class, a select box is added to the heading
+ * which all the select boxes (assumed to be in the first column) shall be bound to.
+ */
+function initialiseSelectableTables() {
+    let selectableTables = document.querySelectorAll('table.selectable');
+    selectableTables.forEach(table => {
+	let heading = table.querySelector('thead tr th');
+	let input = document.createElement("input");
+	input.type = 'checkbox';
+	input.title = "Check / Uncheck all";
+	input.style.display = 'inline';
+	heading.insertBefore(input, heading.firstChild);
+	input.addEventListener('change', e => {
+	    let value = e.target.checked;
+	    Array.from(table.querySelectorAll('tbody tr td:first-child input[type="checkbox"'))
+		.forEach(cb => {
+		    cb.checked = value;
+		});
+	});
+    });
 }
 
 window.submitDummyForm = submitDummyForm;
@@ -580,6 +590,7 @@ function init() {
 }
 
 $(init);
+$(initialiseSelectableTables);
 
 window.submitSetTime = submitSetTime;
 function submitSetTime(el) {

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -37,7 +37,6 @@ function uploadImage(file) {
 	document.getElementById("uploader").href = "";
 	var reader = new FileReader();
 	reader.onloadend = function () {
-		console.log('Doin');
 		$.ajax({
 			url: 'https://api.imgur.com/3/image',
 			type: 'post',
@@ -348,7 +347,7 @@ function quickCite(id){
  */
 function initialiseSelectableTables() {
     let selectableTables = document.querySelectorAll('table.selectable');
-    selectableTables.forEach(table => {
+    for (let table of Array.from(selectableTables)) {
 	let heading = table.querySelector('thead tr th');
 	let input = document.createElement("input");
 	input.type = 'checkbox';
@@ -357,12 +356,12 @@ function initialiseSelectableTables() {
 	heading.insertBefore(input, heading.firstChild);
 	input.addEventListener('change', e => {
 	    let value = e.target.checked;
-	    Array.from(table.querySelectorAll('tbody tr td:first-child input[type="checkbox"'))
-		.forEach(cb => {
-		    cb.checked = value;
-		});
+	    let checkboxes = table.querySelectorAll('tbody tr td:first-child input[type="checkbox"]');
+	    for (let cb of checkboxes) {
+		cb.checked = value;
+	    }
 	});
-    });
+    }
 }
 
 window.submitDummyForm = submitDummyForm;

--- a/watchlist.php
+++ b/watchlist.php
@@ -16,14 +16,15 @@ echo '<form name="watch_list" action="" method="post">';
 
 $stmt = $link->db_exec('SELECT watchlists.topic_id, topics.headline, topics.replies, topics.visits, topics.time FROM watchlists INNER JOIN topics ON watchlists.topic_id = topics.id WHERE watchlists.uid = %1 ORDER BY last_post DESC', $_SESSION['UID']);
 
-$topics = new table();
-$topic_column = '<script type="text/javascript"> document.write(\'<input type="checkbox" name="master_checkbox" class="inline" onclick="checkOrUncheckAllCheckboxes()" title="Check/uncheck all" /> \');</script>Topic';
+$topics = new table('selectable');
+$topic_column = 'Topic';
 $columns = array(
     $topic_column,
     'Replies',
     'Visits',
     'Age ▼',
 );
+$topics->add_table_class('selectable');
 $topics->define_columns($columns, $topic_column);
 $topics->add_td_class($topic_column, 'topic_headline');
 


### PR DESCRIPTION
There is a JavaScript error on the watchlists page but the simple fix revealed a few other issues. As a result I decided to have a go at reworking it completely.
A slight imperfection is introduced in that the "master" checkbox appears after the page is rendered. This may be fixable but the checkbox should not be present when JavaScript is disabled.
NB: I still need to configure my editor to handle tabs but I can fix that while you review the actual code.