### PR TITLE
Stop revealing spoilers in mobile mode.

### DIFF
--- a/style/mobile.css
+++ b/style/mobile.css
@@ -76,11 +76,6 @@ overflow:hidden!important;
 padding:.5em!important;
 }
 
-.spoiler {
-background-color:#000!important;
-color:#666!important;
-}
-
 .standalone {
 margin-bottom:1em!important;
 }


### PR DESCRIPTION
Turns out revealing spoilers in mobile.css is a bug not a feature. Removing the rule fixes this issue.