### PR TITLE
Allow scrolling on codeboxes

### DIFF
--- a/style/layout.css
+++ b/style/layout.css
@@ -59,8 +59,7 @@ div#body_wrapper h2 {
 .codebox2 {
     overflow: auto;
     margin: 0;
-	display: inline-block;
-	line-height: normal;
+    line-height: normal;
 }
 
 .codebox {
@@ -378,7 +377,7 @@ body.rounded a.video,
 body.rounded #main_menu,
 body.rounded table,
 body.rounded ul.body.standalone
-{     
+{
     border-radius: 9px;
 }
 


### PR DESCRIPTION
This enables horizontal scrolling for` [code]..[/code]` tags.
The behaviour is different on mobile mode in that removing the `inline-block` causes text wrapping on the Android default browser. This did not seem ideal until I viewed a StackOverflow post from a mobile and found that here code markup wraps rather than being scrollable also. They must have changed that recently because it used to scroll.

If you are happy to wrap source code on mobile then removing the `display: inline-block` is sufficient.